### PR TITLE
font-boldスタイル未定義だったので追加

### DIFF
--- a/frontend_src/scss/lib/module/_type.scss
+++ b/frontend_src/scss/lib/module/_type.scss
@@ -16,13 +16,13 @@ h1, h2, h3, h4, h5, h6 {
     line-height: 1;
     color: $color-gray-light;
   }
-  
+
   .shoulder {
     display: block;
     margin-bottom: .5em;
     font-size: $font-size-large;
   }
-  
+
   &.no-margin {
     margin-top: 0 !important;
     margin-bottom: 0 !important;
@@ -216,6 +216,11 @@ sub {
   li {
     margin: .5em 0;
   }
+}
+
+//太字
+.font-bold {
+  font-weight: bold;
 }
 
 //強調色

--- a/public/css/lib/module.css
+++ b/public/css/lib/module.css
@@ -295,6 +295,10 @@ sub {
   margin: .5em 0;
 }
 
+.font-bold {
+  font-weight: bold;
+}
+
 em {
   font-style: normal;
   color: #df7802;


### PR DESCRIPTION
以下のように「太字」がBoldになるスタイルがなかったので追加しました。
## Before

![image](https://cloud.githubusercontent.com/assets/1174586/13655960/7fec9278-e6a6-11e5-90b0-34d6ff52b5ce.png)
## After

![image](https://cloud.githubusercontent.com/assets/1174586/13655973/8b6d54b6-e6a6-11e5-9a57-31e0850b5427.png)
